### PR TITLE
Add device capability discovery and extended attribute support

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -159,33 +159,23 @@ export class WinixAPI {
   static async getDeviceStatus(deviceId: string): Promise<DeviceStatus> {
     const attributes: StatusAttributes = await this.getDeviceStatusAttributes(deviceId);
 
-    let airQuality: AirQuality;
-    if (AirQualityValues.has(attributes.S07 as AirQuality)) {
-      airQuality = attributes.S07 as AirQuality;
-    } else {
-      // Map the air quality value to the expected enum
-      const quality = parseFloat(attributes.S07);
-
-      if (quality >= 2.1) {
-        airQuality = AirQuality.Poor;
-      } else if (quality >= 1.1) {
-        airQuality = AirQuality.Fair;
-      } else {
-        airQuality = AirQuality.Good;
-      }
-    }
-
     const status: DeviceStatus = {
-      power: attributes.A02 as Power,
-      mode: attributes.A03 as Mode,
-      airflow: attributes.A04 as Airflow,
-      airQuality: airQuality as AirQuality,
-      plasmawave: attributes.A07 as Plasmawave,
-      ambientLight: parseInt(attributes.S14, 10),
-      filterHours: parseInt(attributes.A21, 10),
+      power: attributes[Attribute.Power] as Power,
+      mode: attributes[Attribute.Mode] as Mode,
+      airflow: attributes[Attribute.Airflow] as Airflow,
+      filterHours: parseInt(attributes[Attribute.FilterHours], 10),
     };
 
     // Populate optional fields if present
+    if (attributes[Attribute.AirQuality] !== undefined) {
+      status.airQuality = this.parseAirQuality(attributes[Attribute.AirQuality]);
+    }
+    if (attributes[Attribute.Plasmawave] !== undefined) {
+      status.plasmawave = attributes[Attribute.Plasmawave] as Plasmawave;
+    }
+    if (attributes[Attribute.AmbientLight] !== undefined) {
+      status.ambientLight = parseInt(attributes[Attribute.AmbientLight], 10);
+    }
     if (attributes[Attribute.ChildLock] !== undefined) {
       status.childLock = attributes[Attribute.ChildLock] as ChildLock;
     }
@@ -227,6 +217,23 @@ export class WinixAPI {
   }
 
   // Private helpers
+
+  private static parseAirQuality(value: string): AirQuality {
+    if (AirQualityValues.has(value as AirQuality)) {
+      return value as AirQuality;
+    }
+
+    // Map numeric air quality value to the expected enum
+    const quality = parseFloat(value);
+
+    if (quality >= 2.1) {
+      return AirQuality.Poor;
+    } else if (quality >= 1.1) {
+      return AirQuality.Fair;
+    }
+
+    return AirQuality.Good;
+  }
 
   private static async getDeviceStatusAttributes(deviceId: string): Promise<StatusAttributes> {
     const url: string = WinixAPI.getDeviceStatusUrl(deviceId);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,7 @@
-import { Airflow, AirQuality, Attribute, AttributeValue, DeviceStatus, Mode, Plasmawave, Power } from './device';
+import {
+  Airflow, AirQuality, Attribute, AttributeValue, Brightness, ChildLock,
+  DeviceCapabilities, DeviceStatus, Mode, Plasmawave, PollutionLamp, Power, Timer, UV,
+} from './device';
 import { SetAttributeResponse, StatusAttributes, StatusBody, StatusResponse } from './response';
 import { getErrorMessage, isResponseError } from './error';
 import axios, { AxiosResponse } from 'axios';
@@ -13,6 +16,8 @@ const AirQualityValues = new Set(
 
 export class WinixAPI {
 
+  // Power
+
   static async getPower(deviceId: string): Promise<Power> {
     return await this.getDeviceAttribute(deviceId, Attribute.Power) as Power;
   }
@@ -20,6 +25,8 @@ export class WinixAPI {
   static async setPower(deviceId: string, value: Power): Promise<Power> {
     return await this.setDeviceAttribute(deviceId, Attribute.Power, value) as Power;
   }
+
+  // Mode
 
   static async getMode(deviceId: string): Promise<Mode> {
     return await this.getDeviceAttribute(deviceId, Attribute.Mode) as Mode;
@@ -29,6 +36,8 @@ export class WinixAPI {
     return await this.setDeviceAttribute(deviceId, Attribute.Mode, value) as Mode;
   }
 
+  // Airflow
+
   static async getAirflow(deviceId: string): Promise<Airflow> {
     return await this.getDeviceAttribute(deviceId, Attribute.Airflow) as Airflow;
   }
@@ -37,9 +46,13 @@ export class WinixAPI {
     return await this.setDeviceAttribute(deviceId, Attribute.Airflow, value) as Airflow;
   }
 
+  // Air Quality
+
   static async getAirQuality(deviceId: string): Promise<AirQuality> {
     return await this.getDeviceAttribute(deviceId, Attribute.AirQuality) as AirQuality;
   }
+
+  // Plasmawave
 
   static async getPlasmawave(deviceId: string): Promise<Plasmawave> {
     return await this.getDeviceAttribute(deviceId, Attribute.Plasmawave) as Plasmawave;
@@ -48,6 +61,58 @@ export class WinixAPI {
   static async setPlasmawave(deviceId: string, value: Plasmawave): Promise<Plasmawave> {
     return await this.setDeviceAttribute(deviceId, Attribute.Plasmawave, value) as Plasmawave;
   }
+
+  // Child Lock
+
+  static async getChildLock(deviceId: string): Promise<ChildLock> {
+    return await this.getDeviceAttribute(deviceId, Attribute.ChildLock) as ChildLock;
+  }
+
+  static async setChildLock(deviceId: string, value: ChildLock): Promise<ChildLock> {
+    return await this.setDeviceAttribute(deviceId, Attribute.ChildLock, value) as ChildLock;
+  }
+
+  // Pollution Lamp
+
+  static async getPollutionLamp(deviceId: string): Promise<PollutionLamp> {
+    return await this.getDeviceAttribute(deviceId, Attribute.PollutionLamp) as PollutionLamp;
+  }
+
+  static async setPollutionLamp(deviceId: string, value: PollutionLamp): Promise<PollutionLamp> {
+    return await this.setDeviceAttribute(deviceId, Attribute.PollutionLamp, value) as PollutionLamp;
+  }
+
+  // UV
+
+  static async getUV(deviceId: string): Promise<UV> {
+    return await this.getDeviceAttribute(deviceId, Attribute.UV) as UV;
+  }
+
+  static async setUV(deviceId: string, value: UV): Promise<UV> {
+    return await this.setDeviceAttribute(deviceId, Attribute.UV, value) as UV;
+  }
+
+  // Brightness
+
+  static async getBrightness(deviceId: string): Promise<Brightness> {
+    return await this.getDeviceAttribute(deviceId, Attribute.Brightness) as Brightness;
+  }
+
+  static async setBrightness(deviceId: string, value: Brightness): Promise<Brightness> {
+    return await this.setDeviceAttribute(deviceId, Attribute.Brightness, value) as Brightness;
+  }
+
+  // Timer
+
+  static async getTimer(deviceId: string): Promise<Timer> {
+    return await this.getDeviceAttribute(deviceId, Attribute.Timer) as Timer;
+  }
+
+  static async setTimer(deviceId: string, value: Timer): Promise<Timer> {
+    return await this.setDeviceAttribute(deviceId, Attribute.Timer, value) as Timer;
+  }
+
+  // Sensors
 
   static async getAmbientLight(deviceId: string): Promise<number> {
     const rawValue: string = await this.getDeviceAttribute(deviceId, Attribute.AmbientLight);
@@ -58,6 +123,38 @@ export class WinixAPI {
 
     return parseInt(rawValue, 10);
   }
+
+  static async getPM25(deviceId: string): Promise<number> {
+    const rawValue: string = await this.getDeviceAttribute(deviceId, Attribute.PM25);
+
+    if (!rawValue || isEmpty(rawValue)) {
+      return -1;
+    }
+
+    return parseInt(rawValue, 10);
+  }
+
+  static async getAirQValue(deviceId: string): Promise<number> {
+    const rawValue: string = await this.getDeviceAttribute(deviceId, Attribute.AirQValue);
+
+    if (!rawValue || isEmpty(rawValue)) {
+      return -1;
+    }
+
+    return parseFloat(rawValue);
+  }
+
+  static async getFilterHours(deviceId: string): Promise<number> {
+    const rawValue: string = await this.getDeviceAttribute(deviceId, Attribute.FilterHours);
+
+    if (!rawValue || isEmpty(rawValue)) {
+      return -1;
+    }
+
+    return parseInt(rawValue, 10);
+  }
+
+  // Device Status & Capabilities
 
   static async getDeviceStatus(deviceId: string): Promise<DeviceStatus> {
     const attributes: StatusAttributes = await this.getDeviceStatusAttributes(deviceId);
@@ -78,7 +175,7 @@ export class WinixAPI {
       }
     }
 
-    return {
+    const status: DeviceStatus = {
       power: attributes.A02 as Power,
       mode: attributes.A03 as Mode,
       airflow: attributes.A04 as Airflow,
@@ -87,17 +184,49 @@ export class WinixAPI {
       ambientLight: parseInt(attributes.S14, 10),
       filterHours: parseInt(attributes.A21, 10),
     };
-  }
 
-  static async getFilterHours(deviceId: string): Promise<number> {
-    const rawValue: string = await this.getDeviceAttribute(deviceId, Attribute.FilterHours);
-
-    if (!rawValue || isEmpty(rawValue)) {
-      return -1;
+    // Populate optional fields if present
+    if (attributes[Attribute.ChildLock] !== undefined) {
+      status.childLock = attributes[Attribute.ChildLock] as ChildLock;
+    }
+    if (attributes[Attribute.PollutionLamp] !== undefined) {
+      status.pollutionLamp = attributes[Attribute.PollutionLamp] as PollutionLamp;
+    }
+    if (attributes[Attribute.UV] !== undefined) {
+      status.uv = attributes[Attribute.UV] as UV;
+    }
+    if (attributes[Attribute.Brightness] !== undefined) {
+      status.brightness = attributes[Attribute.Brightness] as Brightness;
+    }
+    if (attributes[Attribute.Timer] !== undefined) {
+      status.timer = attributes[Attribute.Timer] as Timer;
+    }
+    if (attributes[Attribute.FilterDoor] !== undefined) {
+      status.filterDoor = attributes[Attribute.FilterDoor];
+    }
+    if (attributes[Attribute.FilterDetect] !== undefined) {
+      status.filterDetect = attributes[Attribute.FilterDetect];
+    }
+    if (attributes[Attribute.PM25] !== undefined) {
+      status.pm25 = parseInt(attributes[Attribute.PM25], 10);
+    }
+    if (attributes[Attribute.AirQValue] !== undefined) {
+      status.airQValue = parseFloat(attributes[Attribute.AirQValue]);
     }
 
-    return parseInt(rawValue, 10);
+    return status;
   }
+
+  static async getDeviceCapabilities(deviceId: string, modelName?: string): Promise<DeviceCapabilities> {
+    const attributes: StatusAttributes = await this.getDeviceStatusAttributes(deviceId);
+    return new DeviceCapabilities(modelName ?? 'Unknown', Object.keys(attributes));
+  }
+
+  static async getRawAttributes(deviceId: string): Promise<StatusAttributes> {
+    return await this.getDeviceStatusAttributes(deviceId);
+  }
+
+  // Private helpers
 
   private static async getDeviceStatusAttributes(deviceId: string): Promise<StatusAttributes> {
     const url: string = WinixAPI.getDeviceStatusUrl(deviceId);

--- a/src/api.ts
+++ b/src/api.ts
@@ -115,43 +115,19 @@ export class WinixAPI {
   // Sensors
 
   static async getAmbientLight(deviceId: string): Promise<number> {
-    const rawValue: string = await this.getDeviceAttribute(deviceId, Attribute.AmbientLight);
-
-    if (!rawValue || isEmpty(rawValue)) {
-      return -1;
-    }
-
-    return parseInt(rawValue, 10);
+    return this.getNumericAttribute(deviceId, Attribute.AmbientLight);
   }
 
   static async getPM25(deviceId: string): Promise<number> {
-    const rawValue: string = await this.getDeviceAttribute(deviceId, Attribute.PM25);
-
-    if (!rawValue || isEmpty(rawValue)) {
-      return -1;
-    }
-
-    return parseInt(rawValue, 10);
+    return this.getNumericAttribute(deviceId, Attribute.PM25);
   }
 
   static async getAirQValue(deviceId: string): Promise<number> {
-    const rawValue: string = await this.getDeviceAttribute(deviceId, Attribute.AirQValue);
-
-    if (!rawValue || isEmpty(rawValue)) {
-      return -1;
-    }
-
-    return parseFloat(rawValue);
+    return this.getNumericAttribute(deviceId, Attribute.AirQValue, parseFloat);
   }
 
   static async getFilterHours(deviceId: string): Promise<number> {
-    const rawValue: string = await this.getDeviceAttribute(deviceId, Attribute.FilterHours);
-
-    if (!rawValue || isEmpty(rawValue)) {
-      return -1;
-    }
-
-    return parseInt(rawValue, 10);
+    return this.getNumericAttribute(deviceId, Attribute.FilterHours);
   }
 
   // Device Status & Capabilities
@@ -217,6 +193,20 @@ export class WinixAPI {
   }
 
   // Private helpers
+
+  private static async getNumericAttribute(
+    deviceId: string,
+    attribute: Attribute,
+    parser: (value: string) => number = (v) => parseInt(v, 10),
+  ): Promise<number> {
+    const rawValue: string = await this.getDeviceAttribute(deviceId, attribute);
+
+    if (!rawValue || isEmpty(rawValue)) {
+      return -1;
+    }
+
+    return parser(rawValue);
+  }
 
   private static parseAirQuality(value: string): AirQuality {
     if (AirQualityValues.has(value as AirQuality)) {

--- a/src/device.ts
+++ b/src/device.ts
@@ -1,10 +1,22 @@
 export enum Attribute {
+  // Control attributes
   Power = 'A02',
   Mode = 'A03',
   Airflow = 'A04',
   Plasmawave = 'A07',
+  ChildLock = 'A08',
+  PollutionLamp = 'A09',
+  UV = 'A10',
+  FilterDoor = 'A11',
+  FilterDetect = 'A12',
+  Timer = 'A15',
+  Brightness = 'A16',
   FilterHours = 'A21',
+
+  // Sensor attributes
+  PM25 = 'S04',
   AirQuality = 'S07',
+  AirQValue = 'S08',
   AmbientLight = 'S14'
 }
 
@@ -39,6 +51,34 @@ export enum Plasmawave {
   On = '1'
 }
 
+export enum ChildLock {
+  Off = '0',
+  On = '1'
+}
+
+export enum PollutionLamp {
+  Off = '0',
+  On = '1'
+}
+
+export enum UV {
+  Off = '0',
+  On = '1'
+}
+
+export enum Brightness {
+  Off = '0',
+  Low = '1',
+  High = '2'
+}
+
+export enum Timer {
+  Off = '0',
+  OneHour = '1',
+  FourHours = '4',
+  EightHours = '8'
+}
+
 export interface DeviceStatus {
   power: Power;
   mode: Mode;
@@ -47,4 +87,75 @@ export interface DeviceStatus {
   plasmawave: Plasmawave;
   ambientLight: number;
   filterHours: number;
+
+  // Optional attributes (model-dependent)
+  childLock?: ChildLock;
+  pollutionLamp?: PollutionLamp;
+  uv?: UV;
+  brightness?: Brightness;
+  timer?: Timer;
+  filterDoor?: string;
+  filterDetect?: string;
+  pm25?: number;
+  airQValue?: number;
+}
+
+export class DeviceCapabilities {
+
+  readonly availableAttributes: Set<string>;
+
+  constructor(
+    readonly modelName: string,
+    availableAttributes: string[],
+  ) {
+    this.availableAttributes = new Set(availableAttributes);
+  }
+
+  private has(attribute: Attribute): boolean {
+    return this.availableAttributes.has(attribute);
+  }
+
+  get hasPlasmawave(): boolean {
+    return this.has(Attribute.Plasmawave);
+  }
+
+  get hasChildLock(): boolean {
+    return this.has(Attribute.ChildLock);
+  }
+
+  get hasPollutionLamp(): boolean {
+    return this.has(Attribute.PollutionLamp);
+  }
+
+  get hasUV(): boolean {
+    return this.has(Attribute.UV);
+  }
+
+  get hasBrightness(): boolean {
+    return this.has(Attribute.Brightness);
+  }
+
+  get hasTimer(): boolean {
+    return this.has(Attribute.Timer);
+  }
+
+  get hasFilterDoor(): boolean {
+    return this.has(Attribute.FilterDoor);
+  }
+
+  get hasFilterDetect(): boolean {
+    return this.has(Attribute.FilterDetect);
+  }
+
+  get hasPM25(): boolean {
+    return this.has(Attribute.PM25);
+  }
+
+  get hasAirQValue(): boolean {
+    return this.has(Attribute.AirQValue);
+  }
+
+  get hasAmbientLight(): boolean {
+    return this.has(Attribute.AmbientLight);
+  }
 }

--- a/src/device.ts
+++ b/src/device.ts
@@ -80,15 +80,16 @@ export enum Timer {
 }
 
 export interface DeviceStatus {
+  // Common attributes (all models)
   power: Power;
   mode: Mode;
   airflow: Airflow;
-  airQuality: AirQuality;
-  plasmawave: Plasmawave;
-  ambientLight: number;
   filterHours: number;
 
   // Optional attributes (model-dependent)
+  airQuality?: AirQuality;
+  plasmawave?: Plasmawave;
+  ambientLight?: number;
   childLock?: ChildLock;
   pollutionLamp?: PollutionLamp;
   uv?: UV;

--- a/src/device.ts
+++ b/src/device.ts
@@ -68,15 +68,18 @@ export enum UV {
 
 export enum Brightness {
   Off = '0',
-  Low = '1',
-  High = '2'
+  Low = '30',
+  Medium = '70',
+  High = '100'
 }
 
 export enum Timer {
   Off = '0',
   OneHour = '1',
+  TwoHours = '2',
   FourHours = '4',
-  EightHours = '8'
+  EightHours = '8',
+  TwelveHours = '12'
 }
 
 export interface DeviceStatus {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-import { Airflow, AirQuality, DeviceStatus, Mode, Plasmawave, Power } from './device';
+import {
+  Airflow, AirQuality, Brightness, ChildLock, DeviceCapabilities,
+  DeviceStatus, Mode, Plasmawave, PollutionLamp, Power, Timer, UV,
+} from './device';
 import { WinixAccount, WinixExistingAuth } from './account/winix-account';
 import { RefreshTokenExpiredError, WinixAuth, WinixAuthResponse } from './account/winix-auth';
 import { WinixDevice } from './account/winix-device';
@@ -17,5 +20,11 @@ export {
   Airflow,
   AirQuality,
   Plasmawave,
+  ChildLock,
+  PollutionLamp,
+  UV,
+  Brightness,
+  Timer,
   DeviceStatus,
+  DeviceCapabilities,
 };

--- a/src/response.ts
+++ b/src/response.ts
@@ -20,17 +20,6 @@ export interface StatusData {
 }
 
 export interface StatusAttributes {
-  // Control attributes
-  A02: string;
-  A03: string;
-  A04: string;
-  A07: string;
-  A21: string;
-
-  // Sensor attributes
-  S07: string;
-  S14: string;
-
-  // Allow additional attributes for capability discovery
+  // All attributes are dynamic and model-dependent
   [key: string]: string;
 }

--- a/src/response.ts
+++ b/src/response.ts
@@ -20,18 +20,17 @@ export interface StatusData {
 }
 
 export interface StatusAttributes {
-  // Power
+  // Control attributes
   A02: string;
-  // Mode
   A03: string;
-  // Airflow
   A04: string;
-  // Plasmawave
   A07: string;
-  // Filter Hours
   A21: string;
-  // Air Quality
+
+  // Sensor attributes
   S07: string;
-  // Ambient Light
   S14: string;
+
+  // Allow additional attributes for capability discovery
+  [key: string]: string;
 }


### PR DESCRIPTION
## Summary
- Add 9 new device attributes (child lock, brightness, pollution lamp, UV, timer, filter door/detect, PM2.5, raw AQI)
- Add `DeviceCapabilities` class for dynamic, attribute-based capability detection per device
- Add `getDeviceCapabilities()` and `getRawAttributes()` API methods
- Extend `DeviceStatus` with optional model-dependent fields

## Problem
The API only supported 7 hardcoded attributes (power, mode, airflow, plasmawave, air quality, ambient light, filter hours). Many Winix models report additional attributes (child lock, brightness, UV, PM2.5, etc.) that were being silently ignored. There was no way for consumers to discover what features a specific device supports.

## Fix
- Added all known Winix attribute codes to the `Attribute` enum (A08-A16, S04, S08)
- Added enums for new controllable attributes: `ChildLock`, `PollutionLamp`, `UV`, `Brightness`, `Timer`
- Added get/set methods for each new controllable attribute
- Added sensor getters for PM2.5 and raw AQI value
- `StatusAttributes` now uses an index signature so unknown attributes pass through
- `getDeviceStatus()` populates optional fields when the device reports them
- New `DeviceCapabilities` class probes a device's raw attributes and exposes boolean `has*` properties (e.g., `hasChildLock`, `hasPM25`) - no hardcoded model mapping needed
- New `getDeviceCapabilities(deviceId, modelName?)` fetches attributes and returns a capabilities instance
- New `getRawAttributes(deviceId)` exposes the raw attribute dict for advanced use

## Why
This mirrors the approach used in the Home Assistant winix-purifiers integration, which dynamically detects capabilities per device rather than maintaining a brittle model-to-feature mapping. Consumers (like homebridge-winix-purifiers) can now conditionally expose features based on what each device actually supports.