### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip version bump commits from this workflow
+    if: "!startsWith(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump
+        id: bump
+        run: |
+          MESSAGE="${{ github.event.head_commit.message }}"
+          FIRST_LINE=$(echo "$MESSAGE" | head -n1)
+
+          if echo "$FIRST_LINE" | grep -qE '^feat(\(.+\))?!:'; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif echo "$FIRST_LINE" | grep -qE '^feat(\(.+\))?:'; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          elif echo "$FIRST_LINE" | grep -qE '^fix(\(.+\))?:'; then
+            echo "type=patch" >> $GITHUB_OUTPUT
+          else
+            echo "type=none" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Compute new version
+        id: version
+        if: steps.bump.outputs.type != 'none'
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+          BUMP="${{ steps.bump.outputs.type }}"
+          if [ "$BUMP" = "major" ]; then
+            MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
+          elif [ "$BUMP" = "minor" ]; then
+            MINOR=$((MINOR + 1)); PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+
+          VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
+          echo "Bump: ${BUMP} -> ${VERSION}"
+
+      - uses: actions/setup-node@v5
+        if: steps.bump.outputs.type != 'none'
+        with:
+          node-version: 24.x
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        if: steps.bump.outputs.type != 'none'
+        run: npm ci
+
+      - name: Validate
+        if: steps.bump.outputs.type != 'none'
+        run: npm run validate
+
+      - name: Update package.json version
+        if: steps.bump.outputs.type != 'none'
+        run: |
+          npm pkg set version="${{ steps.version.outputs.version }}"
+
+      - name: Commit version bump
+        if: steps.bump.outputs.type != 'none'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git diff --cached --quiet || git commit -m "[skip ci] release: ${{ steps.version.outputs.version }}"
+          git push
+
+      - name: Create tag
+        if: steps.bump.outputs.type != 'none'
+        run: |
+          git tag ${{ steps.version.outputs.tag }}
+          git push origin ${{ steps.version.outputs.tag }}
+
+      - name: Create GitHub Release
+        if: steps.bump.outputs.type != 'none'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+
+      - name: Publish to npm
+        if: steps.bump.outputs.type != 'none'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# winix-api
+
+Winix device API client library for Node.js.
+
+## Commands
+
+- `npm run lint` - lint with eslint (zero warnings allowed)
+- `npm run build` - clean build to dist/
+- `npm run validate` - lint + build
+- `npm test` - run unit tests (vitest)
+- `npm run test:integration` - run integration tests (requires WINIX_USERNAME, WINIX_PASSWORD, WINIX_DEVICE_ID env vars)
+
+## Release Process
+
+Releases are fully automated via GitHub Actions on push to main.
+
+The workflow reads the **first line** of the merge commit message and determines the version bump:
+
+| Commit prefix | Bump | Example |
+|---|---|---|
+| `fix:` or `fix(scope):` | patch | `fix: handle empty status response` |
+| `feat:` or `feat(scope):` | minor | `feat: add child lock support` |
+| `feat!:` or `feat(scope)!:` | major | `feat!: remove deprecated methods` |
+| anything else (`chore:`, `ci:`, `docs:`, etc.) | no release | `chore: update deps` |
+
+**What happens on release:**
+1. Bumps version in package.json
+2. Commits with `[skip ci] release: X.Y.Z`
+3. Creates git tag `vX.Y.Z`
+4. Creates GitHub Release with auto-generated notes
+5. Publishes to npm
+
+**Required secret:** `NPM_TOKEN` in repository settings.
+
+## Style
+
+- Do not use em dashes
+- Conventional commits for all commit messages
+- TypeScript strict mode, CommonJS output


### PR DESCRIPTION
## Summary
- Add release workflow that auto-publishes on push to main based on conventional commit prefixes
- Add CLAUDE.md documenting commands, release process, and style guidelines

## Problem
Releases were fully manual - bump version, tag, push, npm publish. Easy to forget a step or publish inconsistently.

## Fix
New `.github/workflows/release.yml` that triggers on push to main and:
1. Parses the commit message prefix (`fix:` -> patch, `feat:` -> minor, `feat!:` -> major)
2. Skips release for non-release prefixes (`chore:`, `ci:`, `docs:`, etc.)
3. Skips `[skip ci]` commits (its own version bump commits)
4. Bumps package.json, commits, tags, creates GitHub Release with auto-generated notes, publishes to npm

## Why
Consistent, hands-off releases tied to the conventional commit workflow already in use. Modeled after the release workflow in the HA winix-purifiers integration.

## Setup Required
- Add `NPM_TOKEN` secret to the repository settings