### PR TITLE
fix: correct SRP auth to handle negative modular arithmetic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@aws-sdk/client-cognito-identity-provider": "3.716.0",
         "axios": "1.7.9",
         "crc": "4.3.2",
-        "date-fns": "4.1.0",
         "jsonwebtoken": "9.0.2"
       },
       "devDependencies": {
@@ -22,7 +21,7 @@
         "@typescript-eslint/parser": "6.19.0",
         "eslint": "8.56.0",
         "typescript": "5.3.3",
-        "vitest": "^4.1.0"
+        "vitest": "4.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2375,16 +2374,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@aws-sdk/client-cognito-identity-provider": "3.716.0",
     "axios": "1.7.9",
     "crc": "4.3.2",
-    "date-fns": "4.1.0",
     "jsonwebtoken": "9.0.2"
   },
   "devDependencies": {

--- a/src/account/warrant-lite.ts
+++ b/src/account/warrant-lite.ts
@@ -8,7 +8,6 @@ import {
   InitiateAuthCommandOutput,
   RespondToAuthChallengeCommandOutput,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { format } from 'date-fns';
 import crypto from 'crypto';
 
 class ForceChangePasswordException extends Error {
@@ -84,14 +83,14 @@ function calculateU(bigA: bigint, bigB: bigint): bigint {
 }
 
 function powMod(base: bigint, exponent: bigint, modulus: bigint): bigint {
-  let result = BigInt(1);
-  base = base % modulus;
+  let result = 1n;
+  base = ((base % modulus) + modulus) % modulus;
 
-  while (exponent > 0) {
-    if (exponent % BigInt(2) === BigInt(1)) {
+  while (exponent > 0n) {
+    if (exponent % 2n === 1n) {
       result = (result * base) % modulus;
     }
-    exponent = exponent / BigInt(2);
+    exponent = exponent / 2n;
     base = (base * base) % modulus;
   }
 
@@ -234,10 +233,11 @@ export class WarrantLite {
   }
 
   private getFormattedTimestamp(): string {
+    const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     const now = new Date();
-    const utcDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(),
-      now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds()));
+    const pad = (n: number) => n.toString().padStart(2, '0');
 
-    return format(utcDate, 'EEE MMM d HH:mm:ss \'UTC\' yyyy');
+    return `${weekdays[now.getUTCDay()]} ${months[now.getUTCMonth()]} ${now.getUTCDate()} ${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())}:${pad(now.getUTCSeconds())} UTC ${now.getUTCFullYear()}`;
   }
 }

--- a/src/account/winix-auth.ts
+++ b/src/account/winix-auth.ts
@@ -28,11 +28,12 @@ export class RefreshTokenExpiredError extends Error {
 
 export class WinixAuth {
 
-  static async login(username: string, password: string, maxAttempts = 5): Promise<WinixAuthResponse> {
-    const w = new WarrantLite(username, password, COGNITO_CLIENT, COGNITO_USER_POOL_ID, COGNITO_APP_CLIENT_ID, COGNITO_CLIENT_SECRET_KEY);
-
-    // Workaround for Winix's login API failing when user is signed in to the app on another device.
-    const response = await retry(() => w.authenticateUser(), maxAttempts, 3000);
+  static async login(username: string, password: string, maxAttempts = 3): Promise<WinixAuthResponse> {
+    // Retry with a fresh WarrantLite instance per attempt to generate new SRP values each time.
+    const response = await retry(() => {
+      const w = new WarrantLite(username, password, COGNITO_CLIENT, COGNITO_USER_POOL_ID, COGNITO_APP_CLIENT_ID, COGNITO_CLIENT_SECRET_KEY);
+      return w.authenticateUser();
+    }, maxAttempts, 3000);
     const sub = decode(response.AuthenticationResult!.AccessToken!)!.sub as string;
 
     return {


### PR DESCRIPTION
### Summary
- Fix `powMod()` to correctly handle negative BigInt values in SRP computation
- Fix timestamp formatting to use actual UTC instead of local time labeled as UTC
- Create fresh `WarrantLite` instance per retry attempt for independent SRP values
- Remove `date-fns` dependency (no longer needed)

### Problem
The Cognito SRP login was failing intermittently (~50% of the time), requiring up to 5 retries to succeed. This was caused by a bug in the `powMod()` function where JavaScript's BigInt `%` operator preserves the sign of negative values, unlike Python's `%` which always returns non-negative. Since `warrant-lite.ts` was ported from a Python library, this difference was missed.

In `getPasswordAuthenticationKey()`, the expression `serverBValue - this.k * gModPowXN` is negative roughly half the time (depending on the server's random `B` value). When negative, `powMod()` computed a wrong result, producing an invalid SRP signature that Cognito rejected with `NotAuthorizedException: Incorrect username or password`.

Additionally, `date-fns` `format()` always uses the local timezone, so the `TIMESTAMP` sent to Cognito was labeled `UTC` but contained local time values.

### Fix
- Added `+ modulus` normalization in `powMod()` to handle negative bases: `base = ((base % modulus) + modulus) % modulus`
- Replaced `date-fns` formatting with manual `getUTC*()` calls matching the AWS SDK's `DateHelper` pattern
- Moved `WarrantLite` construction inside the retry callback so each attempt gets fresh random SRP `A` values
- Reduced default retry attempts from 5 to 3 (failures should now be rare)

### Why
The `powMod` fix is the critical change. Python's `pow(base, exp, mod)` natively handles negative bases, but this behavior didn't carry over to JavaScript's BigInt `%` operator. The retry mechanism was accidentally masking this bug - each retry gets a fresh challenge from Cognito with a different `B` value, giving a ~50% chance of landing on a positive `intValue2`. With the fix, SRP computation is correct regardless of the server's `B` value.

### Test Plan
Run integration tests on this branch to verify login succeeds consistently:
```
gh workflow run integration.yml --ref fix-srp-auth
```