### PR TITLE
feat: add rate limit handling (RateLimitError + WinixClient)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "rm -rf ./dist && tsc",
     "test": "vitest run",
     "test:integration": "vitest run test/integration.test.ts",
+    "test:integration:rate-limit": "vitest run test/integration-rate-limit.test.ts",
     "validate": "npm run lint && npm run build",
     "prepublishOnly": "npm run lint && npm run build",
     "version": "npm run validate",

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,8 +3,8 @@ import {
   DeviceCapabilities, DeviceStatus, Mode, Plasmawave, PollutionLamp, Power, Timer, UV,
 } from './device';
 import { SetAttributeResponse, StatusAttributes, StatusBody, StatusResponse } from './response';
-import { getErrorMessage, isResponseError } from './error';
-import axios, { AxiosResponse } from 'axios';
+import { getErrorMessage, isResponseError, RateLimitError } from './error';
+import axios, { AxiosResponse, isAxiosError } from 'axios';
 
 const AirQualityValues = new Set(
   [
@@ -227,7 +227,16 @@ export class WinixAPI {
 
   private static async getDeviceStatusAttributes(deviceId: string): Promise<StatusAttributes> {
     const url: string = WinixAPI.getDeviceStatusUrl(deviceId);
-    const result: AxiosResponse<StatusResponse> = await axios.get<StatusResponse>(url);
+
+    let result: AxiosResponse<StatusResponse>;
+    try {
+      result = await axios.get<StatusResponse>(url);
+    } catch (e: unknown) {
+      if (isAxiosError(e) && (e.response?.status === 403 || e.response?.status === 429)) {
+        throw new RateLimitError();
+      }
+      throw e;
+    }
 
     const resultMessage: string = result.data.headers.resultMessage;
     const body: StatusBody = result.data.body;
@@ -246,7 +255,16 @@ export class WinixAPI {
 
   private static async setDeviceAttribute(deviceId: string, attribute: Attribute, value: AttributeValue): Promise<AttributeValue> {
     const url: string = WinixAPI.getSetAttributeUrl(deviceId, attribute, value);
-    const result: AxiosResponse<SetAttributeResponse> = await axios.get<SetAttributeResponse>(url);
+
+    let result: AxiosResponse<SetAttributeResponse>;
+    try {
+      result = await axios.get<SetAttributeResponse>(url);
+    } catch (e: unknown) {
+      if (isAxiosError(e) && (e.response?.status === 403 || e.response?.status === 429)) {
+        throw new RateLimitError();
+      }
+      throw e;
+    }
 
     const resultMessage: string = result.data.headers.resultMessage;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,51 @@
+import { Airflow, DeviceStatus, Mode, Plasmawave, Power } from './device';
+import { RateLimitError } from './error';
+import { WinixAPI } from './api';
+
+const COOLDOWN_MS = 60_000;
+
+export class WinixClient {
+  private cooldownUntil = 0;
+
+  /**
+   * Returns the remaining cooldown time in milliseconds, or 0 if not rate limited.
+   */
+  getCooldownRemaining(): number {
+    return Math.max(0, this.cooldownUntil - Date.now());
+  }
+
+  async getDeviceStatus(deviceId: string): Promise<DeviceStatus> {
+    return this.execute(() => WinixAPI.getDeviceStatus(deviceId));
+  }
+
+  async setPower(deviceId: string, value: Power): Promise<Power> {
+    return this.execute(() => WinixAPI.setPower(deviceId, value));
+  }
+
+  async setMode(deviceId: string, value: Mode): Promise<Mode> {
+    return this.execute(() => WinixAPI.setMode(deviceId, value));
+  }
+
+  async setAirflow(deviceId: string, value: Airflow): Promise<Airflow> {
+    return this.execute(() => WinixAPI.setAirflow(deviceId, value));
+  }
+
+  async setPlasmawave(deviceId: string, value: Plasmawave): Promise<Plasmawave> {
+    return this.execute(() => WinixAPI.setPlasmawave(deviceId, value));
+  }
+
+  private async execute<T>(fn: () => Promise<T>): Promise<T> {
+    if (Date.now() < this.cooldownUntil) {
+      throw new RateLimitError();
+    }
+
+    try {
+      return await fn();
+    } catch (e: unknown) {
+      if (e instanceof RateLimitError) {
+        this.cooldownUntil = Date.now() + COOLDOWN_MS;
+      }
+      throw e;
+    }
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,3 +1,10 @@
+export class RateLimitError extends Error {
+  constructor() {
+    super('Rate limited by Winix API');
+    this.name = 'RateLimitError';
+  }
+}
+
 type ErrorMessages = {
   [key: string]: { x: boolean; displayName?: string };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { WinixAccount, WinixExistingAuth } from './account/winix-account';
 import { RefreshTokenExpiredError, WinixAuth, WinixAuthResponse } from './account/winix-auth';
 import { WinixDevice } from './account/winix-device';
 import { WinixAPI } from './api';
+import { WinixClient } from './client';
+import { RateLimitError } from './error';
 
 export {
   WinixDevice,
@@ -14,6 +16,8 @@ export {
   WinixAuth,
   WinixAuthResponse,
   WinixAPI,
+  WinixClient,
+  RateLimitError,
   RefreshTokenExpiredError,
   Power,
   Mode,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WinixAPI, RateLimitError } from '../src';
+import axios, { AxiosError, AxiosHeaders } from 'axios';
+
+vi.mock('axios', async () => {
+  const actual = await vi.importActual<typeof import('axios')>('axios');
+  return {
+    ...actual,
+    default: {
+      get: vi.fn(),
+    },
+  };
+});
+
+const mockedAxiosGet = vi.mocked(axios.get);
+
+function createAxiosError(status: number): AxiosError {
+  const error = new AxiosError(
+    `Request failed with status code ${status}`,
+    String(status),
+    undefined,
+    undefined,
+    {
+      status,
+      data: { message: 'Forbidden' },
+      statusText: 'Forbidden',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    },
+  );
+  return error;
+}
+
+const DEVICE_ID = 'test-device-123';
+
+const mockStatusResponse = {
+  data: {
+    headers: { resultCode: 'S', resultMessage: 'success' },
+    body: {
+      data: [{
+        attributes: {
+          A02: '1', // Power On
+          A03: '01', // Mode Auto
+          A04: '01', // Airflow Low
+          A21: '100', // FilterHours
+        },
+      }],
+    },
+  },
+};
+
+const mockSetResponse = {
+  data: {
+    headers: { resultCode: 'S', resultMessage: 'success' },
+    body: {},
+  },
+};
+
+describe('WinixAPI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getDeviceStatus', () => {
+    it('should return device status on success', async () => {
+      mockedAxiosGet.mockResolvedValue(mockStatusResponse);
+      const status = await WinixAPI.getDeviceStatus(DEVICE_ID);
+      expect(status.power).toBe('1');
+      expect(status.mode).toBe('01');
+    });
+
+    it('should throw RateLimitError on 403', async () => {
+      mockedAxiosGet.mockRejectedValue(createAxiosError(403));
+      await expect(WinixAPI.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
+    });
+
+    it('should throw RateLimitError on 429', async () => {
+      mockedAxiosGet.mockRejectedValue(createAxiosError(429));
+      await expect(WinixAPI.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
+    });
+
+    it('should rethrow other errors as-is', async () => {
+      const error = createAxiosError(500);
+      mockedAxiosGet.mockRejectedValue(error);
+      await expect(WinixAPI.getDeviceStatus(DEVICE_ID)).rejects.toThrow(AxiosError);
+      await expect(WinixAPI.getDeviceStatus(DEVICE_ID)).rejects.not.toThrow(RateLimitError);
+    });
+
+    it('should rethrow non-axios errors as-is', async () => {
+      mockedAxiosGet.mockRejectedValue(new Error('network failure'));
+      await expect(WinixAPI.getDeviceStatus(DEVICE_ID)).rejects.toThrow('network failure');
+    });
+  });
+
+  describe('setPower', () => {
+    it('should succeed on 200', async () => {
+      mockedAxiosGet.mockResolvedValue(mockSetResponse);
+      const result = await WinixAPI.setPower(DEVICE_ID, '1' as any);
+      expect(result).toBe('1');
+    });
+
+    it('should throw RateLimitError on 403', async () => {
+      mockedAxiosGet.mockRejectedValue(createAxiosError(403));
+      await expect(WinixAPI.setPower(DEVICE_ID, '1' as any)).rejects.toThrow(RateLimitError);
+    });
+
+    it('should throw RateLimitError on 429', async () => {
+      mockedAxiosGet.mockRejectedValue(createAxiosError(429));
+      await expect(WinixAPI.setPower(DEVICE_ID, '1' as any)).rejects.toThrow(RateLimitError);
+    });
+
+    it('should rethrow other errors as-is', async () => {
+      mockedAxiosGet.mockRejectedValue(createAxiosError(500));
+      await expect(WinixAPI.setPower(DEVICE_ID, '1' as any)).rejects.not.toThrow(RateLimitError);
+    });
+  });
+});

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WinixClient, RateLimitError, WinixAPI } from '../src';
+
+vi.mock('../src/api', () => ({
+  WinixAPI: {
+    getDeviceStatus: vi.fn(),
+    setPower: vi.fn(),
+    setMode: vi.fn(),
+    setAirflow: vi.fn(),
+    setPlasmawave: vi.fn(),
+  },
+}));
+
+const DEVICE_ID = 'test-device-123';
+
+const mockStatus = {
+  power: '1',
+  mode: '01',
+  airflow: '01',
+  filterHours: 100,
+};
+
+describe('WinixClient', () => {
+  let client: WinixClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    client = new WinixClient();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('passthrough on success', () => {
+    it('should return device status from WinixAPI', async () => {
+      vi.mocked(WinixAPI.getDeviceStatus).mockResolvedValue(mockStatus as any);
+      const result = await client.getDeviceStatus(DEVICE_ID);
+      expect(result).toEqual(mockStatus);
+      expect(WinixAPI.getDeviceStatus).toHaveBeenCalledWith(DEVICE_ID);
+    });
+
+    it('should pass through setPower', async () => {
+      vi.mocked(WinixAPI.setPower).mockResolvedValue('1' as any);
+      const result = await client.setPower(DEVICE_ID, '1' as any);
+      expect(result).toBe('1');
+    });
+  });
+
+  describe('cooldown on RateLimitError', () => {
+    it('should enter 60s cooldown after RateLimitError', async () => {
+      vi.mocked(WinixAPI.getDeviceStatus).mockRejectedValue(new RateLimitError());
+
+      // First call triggers cooldown
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
+
+      // Second call should throw immediately without calling API
+      vi.mocked(WinixAPI.getDeviceStatus).mockClear();
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
+      expect(WinixAPI.getDeviceStatus).not.toHaveBeenCalled();
+    });
+
+    it('should recover after 60s', async () => {
+      vi.mocked(WinixAPI.getDeviceStatus).mockRejectedValueOnce(new RateLimitError());
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
+
+      vi.advanceTimersByTime(60_000);
+
+      vi.mocked(WinixAPI.getDeviceStatus).mockResolvedValue(mockStatus as any);
+      const result = await client.getDeviceStatus(DEVICE_ID);
+      expect(result).toEqual(mockStatus);
+      expect(WinixAPI.getDeviceStatus).toHaveBeenCalledWith(DEVICE_ID);
+    });
+
+    it('should still be in cooldown before 60s', async () => {
+      vi.mocked(WinixAPI.getDeviceStatus).mockRejectedValueOnce(new RateLimitError());
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
+
+      vi.advanceTimersByTime(59_000);
+
+      vi.mocked(WinixAPI.getDeviceStatus).mockClear();
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
+      expect(WinixAPI.getDeviceStatus).not.toHaveBeenCalled();
+    });
+
+    it('should block all methods during cooldown', async () => {
+      vi.mocked(WinixAPI.getDeviceStatus).mockRejectedValueOnce(new RateLimitError());
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
+
+      await expect(client.setPower(DEVICE_ID, '1' as any)).rejects.toThrow(RateLimitError);
+      expect(WinixAPI.setPower).not.toHaveBeenCalled();
+
+      await expect(client.setMode(DEVICE_ID, '01' as any)).rejects.toThrow(RateLimitError);
+      expect(WinixAPI.setMode).not.toHaveBeenCalled();
+
+      await expect(client.setAirflow(DEVICE_ID, '01' as any)).rejects.toThrow(RateLimitError);
+      expect(WinixAPI.setAirflow).not.toHaveBeenCalled();
+
+      await expect(client.setPlasmawave(DEVICE_ID, '1' as any)).rejects.toThrow(RateLimitError);
+      expect(WinixAPI.setPlasmawave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getCooldownRemaining', () => {
+    it('should return 0 when not rate limited', () => {
+      expect(client.getCooldownRemaining()).toBe(0);
+    });
+
+    it('should return remaining time during cooldown', async () => {
+      vi.mocked(WinixAPI.getDeviceStatus).mockRejectedValueOnce(new RateLimitError());
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
+
+      expect(client.getCooldownRemaining()).toBe(60_000);
+      vi.advanceTimersByTime(30_000);
+      expect(client.getCooldownRemaining()).toBe(30_000);
+    });
+  });
+
+  describe('non-rate-limit errors', () => {
+    it('should not trigger cooldown on other errors', async () => {
+      vi.mocked(WinixAPI.getDeviceStatus).mockRejectedValueOnce(new Error('network error'));
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow('network error');
+
+      expect(client.getCooldownRemaining()).toBe(0);
+
+      vi.mocked(WinixAPI.getDeviceStatus).mockResolvedValue(mockStatus as any);
+      const result = await client.getDeviceStatus(DEVICE_ID);
+      expect(result).toEqual(mockStatus);
+    });
+  });
+});

--- a/test/integration-rate-limit.test.ts
+++ b/test/integration-rate-limit.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { WinixAPI, WinixClient, RateLimitError, Power } from '../src';
+
+const DEVICE_ID = process.env.WINIX_DEVICE_ID;
+
+describe.runIf(DEVICE_ID)('rate limiting integration', () => {
+  it('should throw RateLimitError, block during cooldown, and recover', async () => {
+    const client = new WinixClient();
+
+    // Step 1: Drain the bucket with rapid-fire requests
+    let requestCount = 0;
+    let rateLimited = false;
+
+    while (!rateLimited && requestCount < 100) {
+      try {
+        await client.getDeviceStatus(DEVICE_ID!);
+        requestCount++;
+      } catch (e) {
+        expect(e).toBeInstanceOf(RateLimitError);
+        rateLimited = true;
+      }
+    }
+
+    expect(rateLimited).toBe(true);
+    expect(requestCount).toBeGreaterThan(0);
+
+    // Step 2: Client should block subsequent calls without hitting the API
+    expect(client.getCooldownRemaining()).toBeGreaterThan(0);
+    await expect(client.getDeviceStatus(DEVICE_ID!)).rejects.toThrow(RateLimitError);
+    await expect(client.setPower(DEVICE_ID!, Power.On)).rejects.toThrow(RateLimitError);
+
+    // Step 3: Wait for cooldown + API recovery, then verify it works again
+    await new Promise(r => setTimeout(r, 75_000));
+
+    const status = await client.getDeviceStatus(DEVICE_ID!);
+    expect(status.power).toBeDefined();
+    expect(client.getCooldownRemaining()).toBe(0);
+  }, 180_000);
+
+  it('should not trigger cooldown on invalid device ID', async () => {
+    const client = new WinixClient();
+
+    // A bogus device ID should return an application-level error, not a rate limit
+    try {
+      await client.getDeviceStatus('fake-device-id-does-not-exist');
+    } catch (e) {
+      expect(e).not.toBeInstanceOf(RateLimitError);
+    }
+
+    // Client should not be in cooldown
+    expect(client.getCooldownRemaining()).toBe(0);
+  }, 15_000);
+
+  it('should work normally for a single request after recovery', async () => {
+    // Wait for any leftover rate limit from previous test to clear
+    await new Promise(r => setTimeout(r, 75_000));
+
+    const client = new WinixClient();
+
+    // Single request should succeed and not trigger cooldown
+    const status = await client.getDeviceStatus(DEVICE_ID!);
+    expect(status.power).toBeDefined();
+    expect(client.getCooldownRemaining()).toBe(0);
+
+    // Verify the raw API also returns RateLimitError (not AxiosError) when rate limited
+    let hitLimit = false;
+    for (let i = 0; i < 100 && !hitLimit; i++) {
+      try {
+        await WinixAPI.getDeviceStatus(DEVICE_ID!);
+      } catch (e) {
+        expect(e).toBeInstanceOf(RateLimitError);
+        hitLimit = true;
+      }
+    }
+    expect(hitLimit).toBe(true);
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary
- Add `RateLimitError` class, thrown on HTTP 403 (AWS WAF) and 429 (API Gateway) responses from the IoT API
- Add `WinixClient`: a rate-limit-aware wrapper around the static `WinixAPI` methods with a 60s cooldown after hitting a rate limit
- Both are exported from the package for consumers to use

## Problem
Winix added AWS WAF rate limiting to `us.api.winix-iot.com`. The static `WinixAPI` methods throw a raw `AxiosError` on 403, giving consumers no structured way to detect rate limiting vs other failures. There's also no mechanism to avoid hammering the API during a rate limit window.

Testing confirmed the rate limit behavior:
- ~43 request bucket size, per-IP, covering both status and control endpoints
- 60s cooldown needed for recovery
- 403 responses don't count against the bucket

See regaw-leinad/homebridge-winix-purifiers#36

## Fix
- `RateLimitError` in `error.ts`: typed error class for rate limit detection
- `api.ts`: `getDeviceStatusAttributes()` and `setDeviceAttribute()` now catch `AxiosError` with status 403 or 429 and throw `RateLimitError` instead
- `WinixClient` in `client.ts`: wraps all `WinixAPI` methods consumers use (`getDeviceStatus`, `setPower`, `setMode`, `setAirflow`, `setPlasmawave`). On `RateLimitError`, enters a 60s cooldown where subsequent calls throw immediately without hitting the API. Resets after cooldown expires.
- Unit tests for both the error detection layer and the client cooldown logic
- Integration test that drains the real API bucket, verifies cooldown blocking, and confirms recovery

## Why
Consumers like homebridge-winix-purifiers need to detect rate limiting and coordinate across multiple devices sharing the same IP. The typed error lets them handle rate limits differently from other failures, and the client provides a shared cooldown so multiple devices don't independently hammer a rate-limited API.