### PR TITLE
fix: support Winix Cognito rotation and v1.5.7 mobile API

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: Integration Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 0' # Sunday at 6am UTC
+    - cron: '0 6 * * *' # Daily at 6am UTC
 
 jobs:
   integration:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.claude/
 
 # Ignore compiled code
 dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "winix-api",
       "version": "1.9.0",
       "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.1014.0",
         "@aws-sdk/client-cognito-identity-provider": "3.1014.0",
         "axios": "1.13.6",
         "crc": "4.3.2",
@@ -156,6 +157,56 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.1014.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1014.0.tgz",
+      "integrity": "sha512-NvNThzNvdKigwy9gNQnipeefydZ1HGU1kReXl5FPMxclzNgYB0IzwmJSW0mXICdd7PWARUblcfz72LeoOyXs0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.23",
+        "@aws-sdk/credential-provider-node": "^3.972.24",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.24",
+        "@aws-sdk/region-config-resolver": "^3.972.9",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.10",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/middleware-retry": "^4.4.44",
+        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.43",
+        "@smithy/util-defaults-mode-node": "^4.2.47",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postversion": "git push && git push --tags && rm -rf ./dist"
   },
   "dependencies": {
+    "@aws-sdk/client-cognito-identity": "3.1014.0",
     "@aws-sdk/client-cognito-identity-provider": "3.1014.0",
     "axios": "1.13.6",
     "crc": "4.3.2",

--- a/src/account/warrant-lite.ts
+++ b/src/account/warrant-lite.ts
@@ -113,19 +113,12 @@ export class WarrantLite {
     private client: CognitoIdentityProvider,
     private poolId: string,
     private clientId: string,
-    private clientSecret: string,
   ) {
     this.bigN = hexToLong(nHex);
     this.g = hexToLong(gHex);
     this.k = hexToLong(hexHash('00' + nHex + '0' + gHex));
     this.smallAValue = this.generateRandomSmallA();
     this.largeAValue = this.calculateA();
-  }
-
-  static getSecretHash(username: string, clientId: string, clientSecret: string): string {
-    const message = Buffer.from(username + clientId, 'utf-8');
-    const hmac = crypto.createHmac('sha256', clientSecret).update(message).digest();
-    return hmac.toString('base64');
   }
 
   async authenticateUser(): Promise<RespondToAuthChallengeCommandOutput> {
@@ -199,7 +192,6 @@ export class WarrantLite {
     return {
       USERNAME: this.username,
       SRP_A: longToHex(this.largeAValue),
-      SECRET_HASH: WarrantLite.getSecretHash(this.username, this.clientId, this.clientSecret),
     };
   }
 
@@ -228,7 +220,6 @@ export class WarrantLite {
       USERNAME: userIdForSrp,
       PASSWORD_CLAIM_SECRET_BLOCK: secretBlockB64,
       PASSWORD_CLAIM_SIGNATURE: signatureString,
-      SECRET_HASH: WarrantLite.getSecretHash(this.username, this.clientId, this.clientSecret),
     };
   }
 

--- a/src/account/winix-account.ts
+++ b/src/account/winix-account.ts
@@ -1,13 +1,21 @@
-import { COGNITO_CLIENT_SECRET_KEY, WinixAuth, WinixAuthResponse } from './winix-auth';
+import { COGNITO_REGION, WinixAuth, WinixAuthResponse, COGNITO_USER_POOL_ID } from './winix-auth';
 import { decode, JwtPayload } from 'jsonwebtoken';
 import { WinixDevice } from './winix-device';
 import { crc32 } from 'crc';
 import { mobilePost, MOBILE_APP_VERSION, MOBILE_MODEL } from './winix-crypto';
+import { CognitoIdentity } from '@aws-sdk/client-cognito-identity';
 
 const TOKEN_EXPIRY_BUFFER = 10 * 60 * 1000;
 const URL_GET_DEVICES = 'https://us.mobile.winix-iot.com/getDeviceInfoList';
 const URL_REGISTER_USER = 'https://us.mobile.winix-iot.com/registerUser';
 const URL_CHECK_ACCESS_TOKEN = 'https://us.mobile.winix-iot.com/checkAccessToken';
+const URL_INIT = 'https://us.mobile.winix-iot.com/init';
+
+// Pulled from Winix Smart v1.5.7 APK (AWSAbstractCognitoIdentityProvider.java).
+const IDENTITY_POOL_ID = 'us-east-1:84008e15-d6af-4698-8646-66d05c1abe8b';
+const COGNITO_LOGINS_PROVIDER = `cognito-idp.${COGNITO_REGION}.amazonaws.com/${COGNITO_USER_POOL_ID}`;
+
+const IDENTITY_CLIENT = new CognitoIdentity({ region: COGNITO_REGION });
 
 interface WinixMobileResponse {
   resultCode: string;
@@ -38,6 +46,7 @@ export interface WinixExistingAuth {
 
 export class WinixAccount {
   private uuid: string;
+  private identityId?: string;
 
   private constructor(private username: string, private auth: WinixAuthResponse) {
     this.uuid = WinixAccount.generateUuid(auth.accessToken);
@@ -72,8 +81,7 @@ export class WinixAccount {
    */
   static async from(username: string, auth: WinixAuthResponse): Promise<WinixAccount> {
     const account = new WinixAccount(username, auth);
-    await account.registerUser();
-    await account.checkAccessToken();
+    await account.establishSession();
     return account;
   }
 
@@ -82,14 +90,8 @@ export class WinixAccount {
    */
   async getDevices(): Promise<WinixDevice[]> {
     const response = await mobilePost<WinixDevicesResponse>(URL_GET_DEVICES, {
-      cognitoClientSecretKey: COGNITO_CLIENT_SECRET_KEY,
       accessToken: await this.getAccessToken(),
       uuid: this.uuid,
-      osType: 'android',
-      osVersion: '29',
-      mobileLang: 'en',
-      appVersion: MOBILE_APP_VERSION,
-      mobileModel: MOBILE_MODEL,
     });
 
     return response.deviceInfoList;
@@ -104,7 +106,18 @@ export class WinixAccount {
     this.auth = await WinixAuth.refresh(this.auth.refreshToken, this.auth.userId);
     // Generate a new uuid based on the new access token
     this.uuid = WinixAccount.generateUuid(this.auth.accessToken);
+    await this.establishSession();
+  }
+
+  /**
+   * Run the Winix mobile handshake that follows a fresh login or token refresh.
+   * Order is load-bearing: identityId is needed by registerUser/checkAccessToken,
+   * and /init sits between registerUser and checkAccessToken as of v1.5.7.
+   */
+  private async establishSession(): Promise<void> {
+    await this.resolveIdentityId();
     await this.registerUser();
+    await this.init();
     await this.checkAccessToken();
   }
 
@@ -126,14 +139,24 @@ export class WinixAccount {
   }
 
   /**
-   * Register the logged-in android login/uuid with the Winix API.
-   *
-   * Call after getting a cognito access token, but before checkAccessToken(). This is necessary for the winix backend
-   * to recognize the android "uuid" we send in these api requests.
+   * Resolve the Cognito Identity Pool identity id for the current user.
+   * Required in the mobile API payload as of Winix Smart v1.5.7.
+   */
+  private async resolveIdentityId(): Promise<void> {
+    const response = await IDENTITY_CLIENT.getId({
+      IdentityPoolId: IDENTITY_POOL_ID,
+      Logins: { [COGNITO_LOGINS_PROVIDER]: this.auth.idToken },
+    });
+    this.identityId = response.IdentityId!;
+  }
+
+  /**
+   * Register the logged-in android login/uuid with the Winix API. The winix backend
+   * needs to see this registration before it accepts the "uuid" we send on later calls.
    */
   private async registerUser(): Promise<void> {
     await mobilePost<WinixMobileResponse>(URL_REGISTER_USER, {
-      cognitoClientSecretKey: COGNITO_CLIENT_SECRET_KEY,
+      identityId: this.identityId,
       accessToken: await this.getAccessToken(),
       uuid: this.uuid,
       email: this.username,
@@ -146,14 +169,24 @@ export class WinixAccount {
   }
 
   /**
+   * Winix mobile API init endpoint. Called after registerUser() as of v1.5.7.
+   */
+  private async init(): Promise<void> {
+    await mobilePost<WinixMobileResponse>(URL_INIT, {
+      accessToken: await this.getAccessToken(),
+      uuid: this.uuid,
+      region: 'US',
+    });
+  }
+
+  /**
    * Confirm the validity of the access token with the Winix API.
    */
   private async checkAccessToken(): Promise<void> {
     await mobilePost<WinixMobileResponse>(URL_CHECK_ACCESS_TOKEN, {
-      cognitoClientSecretKey: COGNITO_CLIENT_SECRET_KEY,
+      identityId: this.identityId,
       accessToken: await this.getAccessToken(),
       uuid: this.uuid,
-      osType: 'android',
       osVersion: '29',
       mobileLang: 'en',
       appVersion: MOBILE_APP_VERSION,

--- a/src/account/winix-account.ts
+++ b/src/account/winix-account.ts
@@ -113,12 +113,16 @@ export class WinixAccount {
    * Run the Winix mobile handshake that follows a fresh login or token refresh.
    * Order is load-bearing: identityId is needed by registerUser/checkAccessToken,
    * and /init sits between registerUser and checkAccessToken as of v1.5.7.
+   *
+   * Uses this.auth.accessToken directly (not getAccessToken) so a stale isExpired()
+   * check can't recursively trigger another refresh mid-handshake.
    */
   private async establishSession(): Promise<void> {
+    const accessToken = this.auth.accessToken;
     await this.resolveIdentityId();
-    await this.registerUser();
-    await this.init();
-    await this.checkAccessToken();
+    await this.registerUser(accessToken);
+    await this.init(accessToken);
+    await this.checkAccessToken(accessToken);
   }
 
   private async getAccessToken(): Promise<string> {
@@ -147,17 +151,20 @@ export class WinixAccount {
       IdentityPoolId: IDENTITY_POOL_ID,
       Logins: { [COGNITO_LOGINS_PROVIDER]: this.auth.idToken },
     });
-    this.identityId = response.IdentityId!;
+    if (!response.IdentityId) {
+      throw new Error('Cognito GetId returned no IdentityId');
+    }
+    this.identityId = response.IdentityId;
   }
 
   /**
    * Register the logged-in android login/uuid with the Winix API. The winix backend
    * needs to see this registration before it accepts the "uuid" we send on later calls.
    */
-  private async registerUser(): Promise<void> {
+  private async registerUser(accessToken: string): Promise<void> {
     await mobilePost<WinixMobileResponse>(URL_REGISTER_USER, {
       identityId: this.identityId,
-      accessToken: await this.getAccessToken(),
+      accessToken,
       uuid: this.uuid,
       email: this.username,
       osType: 'android',
@@ -171,9 +178,9 @@ export class WinixAccount {
   /**
    * Winix mobile API init endpoint. Called after registerUser() as of v1.5.7.
    */
-  private async init(): Promise<void> {
+  private async init(accessToken: string): Promise<void> {
     await mobilePost<WinixMobileResponse>(URL_INIT, {
-      accessToken: await this.getAccessToken(),
+      accessToken,
       uuid: this.uuid,
       region: 'US',
     });
@@ -182,10 +189,10 @@ export class WinixAccount {
   /**
    * Confirm the validity of the access token with the Winix API.
    */
-  private async checkAccessToken(): Promise<void> {
+  private async checkAccessToken(accessToken: string): Promise<void> {
     await mobilePost<WinixMobileResponse>(URL_CHECK_ACCESS_TOKEN, {
       identityId: this.identityId,
-      accessToken: await this.getAccessToken(),
+      accessToken,
       uuid: this.uuid,
       osVersion: '29',
       mobileLang: 'en',

--- a/src/account/winix-auth.ts
+++ b/src/account/winix-auth.ts
@@ -2,10 +2,9 @@ import { CognitoIdentityProvider, NotAuthorizedException } from '@aws-sdk/client
 import { WarrantLite } from './warrant-lite';
 import { decode } from 'jsonwebtoken';
 
-// Pulled from Winix Home v1.0.8 (Android) APK
-// thanks to https://github.com/hfern/winix
-export const COGNITO_APP_CLIENT_ID = '14og512b9u20b8vrdm55d8empi';
-export const COGNITO_CLIENT_SECRET_KEY = 'k554d4pvgf2n0chbhgtmbe4q0ul4a9flp3pcl6a47ch6rripvvr';
+// Pulled from Winix Smart v1.5.7 (Android) APK.
+// Winix rotated the client on 2026-04-16 and moved to a public client (no secret).
+export const COGNITO_APP_CLIENT_ID = '5rjk59c5tt7k9g8gpj0vd2qfg9';
 export const COGNITO_USER_POOL_ID = 'us-east-1_Ofd50EosD';
 export const COGNITO_REGION = 'us-east-1';
 
@@ -16,6 +15,7 @@ const COGNITO_CLIENT = new CognitoIdentityProvider({
 export interface WinixAuthResponse {
   userId: string;
   accessToken: string;
+  idToken: string;
   expiresAt: number;
   refreshToken: string;
 }
@@ -31,7 +31,7 @@ export class WinixAuth {
   static async login(username: string, password: string, maxAttempts = 3): Promise<WinixAuthResponse> {
     // Retry with a fresh WarrantLite instance per attempt to generate new SRP values each time.
     const response = await retry(() => {
-      const w = new WarrantLite(username, password, COGNITO_CLIENT, COGNITO_USER_POOL_ID, COGNITO_APP_CLIENT_ID, COGNITO_CLIENT_SECRET_KEY);
+      const w = new WarrantLite(username, password, COGNITO_CLIENT, COGNITO_USER_POOL_ID, COGNITO_APP_CLIENT_ID);
       return w.authenticateUser();
     }, maxAttempts, 3000);
     const sub = decode(response.AuthenticationResult!.AccessToken!)!.sub as string;
@@ -39,6 +39,7 @@ export class WinixAuth {
     return {
       userId: sub,
       accessToken: response.AuthenticationResult!.AccessToken!,
+      idToken: response.AuthenticationResult!.IdToken!,
       expiresAt: toExpiresAt(response.AuthenticationResult!.ExpiresIn!),
       refreshToken: response.AuthenticationResult!.RefreshToken!,
     };
@@ -47,7 +48,6 @@ export class WinixAuth {
   static async refresh(refreshToken: string, userId: string): Promise<WinixAuthResponse> {
     const authParams = {
       REFRESH_TOKEN: refreshToken,
-      SECRET_HASH: WarrantLite.getSecretHash(userId, COGNITO_APP_CLIENT_ID, COGNITO_CLIENT_SECRET_KEY),
     };
 
     let response;
@@ -68,6 +68,7 @@ export class WinixAuth {
     return {
       userId: userId,
       accessToken: response.AuthenticationResult!.AccessToken!,
+      idToken: response.AuthenticationResult!.IdToken!,
       expiresAt: toExpiresAt(response.AuthenticationResult!.ExpiresIn!),
       refreshToken: refreshToken,
     };

--- a/src/account/winix-crypto.ts
+++ b/src/account/winix-crypto.ts
@@ -1,11 +1,16 @@
 import { createCipheriv, createDecipheriv } from 'crypto';
 import axios from 'axios';
 
+interface MobileResponseEnvelope {
+  resultCode?: string;
+  resultMessage?: string;
+}
+
 // Extracted from Winix Smart v1.5.6 APK native library (libnative-lib.so)
 const AES_KEY = Buffer.from('84be38f854e320dd4a0a8c7fe0f3a9b84c288445916933fc222465bbd5a518d0', 'hex');
 const AES_IV = Buffer.from('dfd55f316e72e97b905f8739005c99a7', 'hex');
 
-export const MOBILE_APP_VERSION = '1.5.6';
+export const MOBILE_APP_VERSION = '1.5.7';
 export const MOBILE_MODEL = 'SM-G988B';
 
 /**
@@ -27,6 +32,8 @@ export function decrypt<T>(data: Buffer): T {
 
 /**
  * Send an encrypted POST request to the Winix mobile API and return the decrypted response.
+ * On any non-success, throws an Error that includes the server's resultCode and resultMessage
+ * (the mobile API returns these inside an AES-encrypted body even on HTTP errors).
  */
 export async function mobilePost<T>(url: string, payload: object): Promise<T> {
   const response = await axios.post(url, encrypt(payload), {
@@ -35,11 +42,39 @@ export async function mobilePost<T>(url: string, payload: object): Promise<T> {
       'Accept': 'application/octet-stream',
     },
     responseType: 'arraybuffer',
+    validateStatus: () => true,
   });
 
+  const body = tryDecryptBody<T & MobileResponseEnvelope>(response.data);
+
   if (response.status !== 200) {
-    throw new Error(`Error calling ${url} (${response.status})`);
+    const code = body?.resultCode ?? 'unknown';
+    const message = body?.resultMessage ?? `HTTP ${response.status} with no decryptable body`;
+    throw new Error(`${url} failed (HTTP ${response.status}, resultCode=${code}): ${message}`);
   }
 
-  return decrypt<T>(Buffer.from(response.data));
+  if (body === undefined) {
+    throw new Error(`${url} returned an empty or undecryptable response body`);
+  }
+
+  if (body.resultCode && body.resultCode !== '200') {
+    throw new Error(`${url} returned resultCode=${body.resultCode}: ${body.resultMessage ?? 'no resultMessage'}`);
+  }
+
+  return body;
+}
+
+function tryDecryptBody<T>(data: unknown): T | undefined {
+  if (!data) {
+    return undefined;
+  }
+  const buf = Buffer.from(data as ArrayBuffer);
+  if (buf.byteLength === 0) {
+    return undefined;
+  }
+  try {
+    return decrypt<T>(buf);
+  } catch {
+    return undefined;
+  }
 }

--- a/test/mobile-post.test.ts
+++ b/test/mobile-post.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import { mobilePost, encrypt } from '../src/account/winix-crypto';
+
+vi.mock('axios', async () => {
+  const actual = await vi.importActual<typeof import('axios')>('axios');
+  return {
+    ...actual,
+    default: { post: vi.fn() },
+  };
+});
+
+const mockedPost = vi.mocked(axios.post);
+
+const URL = 'https://us.mobile.winix-iot.com/registerUser';
+
+function encryptedResponse(status: number, body: object | null) {
+  const data = body === null ? Buffer.alloc(0) : encrypt(body);
+  return { status, data: data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) };
+}
+
+describe('mobilePost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the decrypted body on HTTP 200 with resultCode=200', async () => {
+    mockedPost.mockResolvedValue(encryptedResponse(200, { resultCode: '200', resultMessage: 'ok', data: 42 }));
+    const result = await mobilePost<{ data: number }>(URL, { foo: 'bar' });
+    expect(result.data).toBe(42);
+  });
+
+  it('throws with server resultCode/resultMessage on HTTP 400 with an encrypted body', async () => {
+    mockedPost.mockResolvedValue(encryptedResponse(400, { resultCode: '401', resultMessage: 'identityId missing' }));
+    await expect(mobilePost(URL, {})).rejects.toThrow(/HTTP 400.*resultCode=401.*identityId missing/);
+  });
+
+  it('throws with HTTP info when the non-2xx body cannot be decrypted', async () => {
+    mockedPost.mockResolvedValue({ status: 502, data: Buffer.from('<html>gateway</html>').buffer });
+    await expect(mobilePost(URL, {})).rejects.toThrow(/HTTP 502.*no decryptable body/);
+  });
+
+  it('throws when HTTP 200 but server resultCode is not 200', async () => {
+    mockedPost.mockResolvedValue(encryptedResponse(200, { resultCode: '403', resultMessage: 'invalid access token' }));
+    await expect(mobilePost(URL, {})).rejects.toThrow(/resultCode=403.*invalid access token/);
+  });
+
+  it('throws on empty response body', async () => {
+    mockedPost.mockResolvedValue(encryptedResponse(200, null));
+    await expect(mobilePost(URL, {})).rejects.toThrow(/empty or undecryptable/);
+  });
+});

--- a/test/mobile-post.test.ts
+++ b/test/mobile-post.test.ts
@@ -16,7 +16,7 @@ const URL = 'https://us.mobile.winix-iot.com/registerUser';
 
 function encryptedResponse(status: number, body: object | null) {
   const data = body === null ? Buffer.alloc(0) : encrypt(body);
-  return { status, data: data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) };
+  return { status, data };
 }
 
 describe('mobilePost', () => {
@@ -36,7 +36,7 @@ describe('mobilePost', () => {
   });
 
   it('throws with HTTP info when the non-2xx body cannot be decrypted', async () => {
-    mockedPost.mockResolvedValue({ status: 502, data: Buffer.from('<html>gateway</html>').buffer });
+    mockedPost.mockResolvedValue({ status: 502, data: Buffer.from('<html>gateway</html>') });
     await expect(mobilePost(URL, {})).rejects.toThrow(/HTTP 502.*no decryptable body/);
   });
 


### PR DESCRIPTION
### Summary
- New Cognito app client ID (Winix rotated it on 2026-04-16 and moved to a public client - no secret)
- Port the Winix mobile API payloads to what v1.5.7 actually sends (`identityId`, new `/init` call, slimmed `getDeviceInfoList`)
- Better error reporting from `mobilePost` - decrypt the server's error body instead of swallowing it

### Problem
Users reported that login stopped working on 2026-04-16. Stack traces on issue regaw-leinad/homebridge-winix-purifiers#41 and iprak/winix#155 showed `ResourceNotFoundException: User pool client 14og512b9u20b8vrdm55d8empi does not exist`. Winix had rotated their Cognito app client and, in the same release, changed the mobile API payload shape - so a naive client-ID swap alone isn't enough. The old `mobilePost` also swallowed non-2xx responses as generic `AxiosError`s, which made diagnosing the payload rejection slower than it should have been.

### Fix
Reverse-engineered Winix Smart v1.5.7 (Android) to extract the new auth topology and mirror it:

- **Cognito (`winix-auth.ts`, `warrant-lite.ts`)**
  - Client ID: `14og512b9u20b8vrdm55d8empi` -> `5rjk59c5tt7k9g8gpj0vd2qfg9`
  - Removed `COGNITO_CLIENT_SECRET_KEY` - the new client is public, no secret
  - `WinixAuthResponse` now carries `idToken` (needed for Cognito Identity's `GetId`)
  - Dropped all `SECRET_HASH` paths from `WarrantLite` since the client has no secret
- **Mobile API (`winix-account.ts`)**
  - New `resolveIdentityId()` calls `CognitoIdentity.GetId` against the pool `us-east-1:84008e15-d6af-4698-8646-66d05c1abe8b` (extracted from the APK)
  - `registerUser` / `checkAccessToken` now send `identityId` in place of the old `cognitoClientSecretKey` field
  - `checkAccessToken` dropped `osType` (not sent in v1.5.7)
  - `getDeviceInfoList` slimmed from 8 fields to `{accessToken, uuid}`
  - New `/init` POST between `registerUser` and `checkAccessToken`
  - Shared 4-step handshake extracted into `establishSession()` (same sequence used after fresh login and after token refresh)
- **Error reporting (`winix-crypto.ts`)**
  - `mobilePost` now uses `validateStatus: () => true`, always tries to decrypt the body, and throws a plain `Error` carrying the URL, HTTP status, `resultCode`, and server `resultMessage`. Also now catches the silent-failure case of HTTP 200 with a non-200 `resultCode` in the body.
- **CI (`.github/workflows/integration.yml`)**
  - Integration test cron goes from weekly (Sunday 6am UTC) to daily. Would've caught this within 24 hours.
- **Gitignore** - added `.claude/` so local Claude Code settings don't get tracked.

### Why
The minimal Cognito-client-ID swap is not enough: the Winix mobile server validates the new payload shape (returns HTTP 400 when it sees `cognitoClientSecretKey` and no `identityId`). Mirroring exactly what the v1.5.7 Android client sends is the load-bearing choice here. All values (new client ID, identity pool ID, endpoint paths, field sets) came from jadx-decompiled v1.5.7 sources, not guesses.

### Test Plan
- Unit tests added in `test/mobile-post.test.ts` cover the new `mobilePost` error paths (non-2xx with encrypted body, non-2xx with non-decryptable body, HTTP 200 with non-success resultCode, empty body, happy path).
- End-to-end verified locally against a real Winix account: login, getId, registerUser, /init, checkAccessToken, getDeviceInfoList all 200.
- Also verified `fromExistingAuth` (the refresh-token path that goes through `WinixAuth.refresh` then the same `establishSession`) works against the live API.