### PR TITLE
fix: skip airflow assertion in restore test when mode is Auto

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -100,7 +100,11 @@ describe.runIf(hasCredentials)('winix api integration', () => {
       const status = await client.getDeviceStatus(DEVICE_ID!);
       expect(status.power).toBe(originalPower);
       expect(status.mode).toBe(originalMode);
-      expect(status.airflow).toBe(originalAirflow);
+      // In Auto mode the device controls airflow itself based on air quality,
+      // so an explicit setAirflow does not stick. Only assert when restoring to Manual.
+      if (originalMode === Mode.Manual) {
+        expect(status.airflow).toBe(originalAirflow);
+      }
     }, 45_000);
   });
 });


### PR DESCRIPTION
## Summary
- Skip the `airflow` equality check in the "should restore original state" integration test when `originalMode === Mode.Auto`.

## Problem
The nightly integration run has been failing for ~2 weeks on `should restore original state` with `expected '01' to be '06'`. The captured pre-test state was `mode=Auto, airflow=Sleep ('06')`. When the test restores Auto mode and then calls `setAirflow(Sleep)`, the device ignores the explicit airflow because in Auto mode it picks airflow itself based on air quality - and currently it picks Low (`'01'`).

## Fix
Only assert the restored airflow value when the original mode was Manual. Power and mode are still verified unconditionally.

## Why
In Auto mode the device owns the airflow setting, so `setAirflow` is not authoritative and the assertion can never reliably hold. This is a test-design issue, not an API/SDK regression - the underlying calls all succeed.