### PR TITLE
fix: add NoDataError and MobileSessionInvalidError typed errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run",
     "test:integration": "vitest run test/integration.test.ts",
     "test:integration:rate-limit": "vitest run test/integration-rate-limit.test.ts",
+    "test:integration:session": "node --env-file=.env ./node_modules/vitest/vitest.mjs run test/integration-session.test.ts --reporter=verbose",
     "validate": "npm run lint && npm run build",
     "prepublishOnly": "npm run lint && npm run build",
     "version": "npm run validate",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run",
     "test:integration": "vitest run test/integration.test.ts",
     "test:integration:rate-limit": "vitest run test/integration-rate-limit.test.ts",
-    "test:integration:session": "node --env-file=.env ./node_modules/vitest/vitest.mjs run test/integration-session.test.ts --reporter=verbose",
+    "test:integration:session": "node --env-file-if-exists=.env ./node_modules/vitest/vitest.mjs run test/integration-session.test.ts --reporter=verbose",
     "validate": "npm run lint && npm run build",
     "prepublishOnly": "npm run lint && npm run build",
     "version": "npm run validate",

--- a/src/account/winix-crypto.ts
+++ b/src/account/winix-crypto.ts
@@ -1,5 +1,6 @@
 import { createCipheriv, createDecipheriv } from 'crypto';
 import axios from 'axios';
+import { isMobileSessionInvalid, MobileSessionInvalidError } from '../error';
 
 interface MobileResponseEnvelope {
   resultCode?: string;
@@ -50,6 +51,9 @@ export async function mobilePost<T>(url: string, payload: object): Promise<T> {
   if (response.status !== 200) {
     const code = body?.resultCode ?? 'unknown';
     const message = body?.resultMessage ?? `HTTP ${response.status} with no decryptable body`;
+    if (isMobileSessionInvalid(response.status, body?.resultCode)) {
+      throw new MobileSessionInvalidError(code, message, response.status, url);
+    }
     throw new Error(`${url} failed (HTTP ${response.status}, resultCode=${code}): ${message}`);
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import {
   DeviceCapabilities, DeviceStatus, Mode, Plasmawave, PollutionLamp, Power, Timer, UV,
 } from './device';
 import { SetAttributeResponse, StatusAttributes, StatusBody, StatusResponse } from './response';
-import { getErrorMessage, isResponseError, RateLimitError } from './error';
+import { getErrorMessage, isResponseError, NoDataError, RateLimitError } from './error';
 import axios, { AxiosResponse, isAxiosError } from 'axios';
 
 const DEFAULT_COOLDOWN_MS = 60_000;
@@ -261,7 +261,11 @@ export class WinixClient {
       const resultMessage: string = result.data.headers.resultMessage;
       const body: StatusBody = result.data.body;
 
-      if (isResponseError(resultMessage) || isEmpty(body) || isEmpty(body.data)) {
+      if (resultMessage === 'no data' || isEmpty(body) || isEmpty(body.data)) {
+        throw new NoDataError();
+      }
+
+      if (isResponseError(resultMessage)) {
         throw new Error(getErrorMessage(resultMessage));
       }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -5,6 +5,25 @@ export class RateLimitError extends Error {
   }
 }
 
+export class NoDataError extends Error {
+  constructor() {
+    super('no data (invalid or unregistered device?)');
+    this.name = 'NoDataError';
+  }
+}
+
+export class MobileSessionInvalidError extends Error {
+  constructor(
+    public readonly resultCode: string,
+    public readonly resultMessage: string,
+    public readonly httpStatus: number,
+    url: string,
+  ) {
+    super(`${url} failed (HTTP ${httpStatus}, resultCode=${resultCode}): ${resultMessage}`);
+    this.name = 'MobileSessionInvalidError';
+  }
+}
+
 type ErrorMessages = {
   [key: string]: { x: boolean; displayName?: string };
 };
@@ -28,4 +47,11 @@ export const getErrorMessage = (possibleError: string): string => {
   }
 
   return error.displayName;
+};
+
+export const isMobileSessionInvalid = (httpStatus: number, resultCode: string | undefined): boolean => {
+  if (httpStatus !== 400) {
+    return false;
+  }
+  return resultCode === '400' || resultCode === '900';
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { WinixAccount, WinixExistingAuth } from './account/winix-account';
 import { RefreshTokenExpiredError, WinixAuth, WinixAuthResponse } from './account/winix-auth';
 import { WinixDevice } from './account/winix-device';
 import { WinixClient } from './client';
-import { RateLimitError } from './error';
+import { MobileSessionInvalidError, NoDataError, RateLimitError } from './error';
 
 export {
   WinixDevice,
@@ -16,6 +16,8 @@ export {
   WinixAuthResponse,
   WinixClient,
   RateLimitError,
+  NoDataError,
+  MobileSessionInvalidError,
   RefreshTokenExpiredError,
   Power,
   Mode,

--- a/test/integration-session.test.ts
+++ b/test/integration-session.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MobileSessionInvalidError,
+  NoDataError,
+  RateLimitError,
+  WinixAccount,
+  WinixClient,
+} from '../src';
+
+const USERNAME = process.env.WINIX_USERNAME;
+const PASSWORD = process.env.WINIX_PASSWORD;
+const DEVICE_ID = process.env.WINIX_DEVICE_ID;
+
+const canRun = USERNAME && PASSWORD;
+const canRunDevice = canRun && DEVICE_ID;
+
+// Integration tests for issue regaw-leinad/homebridge-winix-purifiers#43.
+//
+// WARNING: running these tests will invalidate the Winix mobile-app
+// session on whatever phone is logged in with the same account. Use a
+// dedicated test account or be prepared to log back in on the phone.
+
+describe.runIf(canRun)('mobile session invalidation', () => {
+  it('second login invalidates first instance: getDevices throws MobileSessionInvalidError', async () => {
+    const account1 = await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+    const baseline = await account1.getDevices();
+    expect(baseline.length).toBeGreaterThan(0);
+
+    await new Promise(r => setTimeout(r, 2000));
+
+    const account2 = await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+    const second = await account2.getDevices();
+    expect(second.length).toBeGreaterThan(0);
+
+    await expect(account1.getDevices()).rejects.toBeInstanceOf(MobileSessionInvalidError);
+  }, 60_000);
+
+  it.runIf(canRunDevice)('control plane (getDeviceStatus) survives mobile session invalidation', async () => {
+    const account1 = await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+    const client1 = new WinixClient(account1.getIdentityId());
+
+    const baseline = await client1.getDeviceStatus(DEVICE_ID!);
+    expect(baseline.power).toBeDefined();
+
+    await new Promise(r => setTimeout(r, 2000));
+    await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+
+    await expect(account1.getDevices()).rejects.toBeInstanceOf(MobileSessionInvalidError);
+
+    const status = await client1.getDeviceStatus(DEVICE_ID!);
+    expect(status.power).toBeDefined();
+  }, 60_000);
+});
+
+describe.runIf(canRun)('control plane error shapes', () => {
+  it('plausible-but-unknown deviceId throws NoDataError', async () => {
+    const account = await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+    const client = new WinixClient(account.getIdentityId());
+    await expect(client.getDeviceStatus('CCCCCCCCCCCC_xxxxxxxxxx')).rejects.toBeInstanceOf(NoDataError);
+  }, 30_000);
+
+  it('real-format-not-mine throws NoDataError', async () => {
+    const account = await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+    const client = new WinixClient(account.getIdentityId());
+    await expect(client.getDeviceStatus('000000000000_aaaaaaaaaa')).rejects.toBeInstanceOf(NoDataError);
+  }, 30_000);
+
+  it('empty deviceId throws RateLimitError', async () => {
+    const account = await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+    const client = new WinixClient(account.getIdentityId());
+    await expect(client.getDeviceStatus('')).rejects.toBeInstanceOf(RateLimitError);
+  }, 30_000);
+
+  // Note: Winix returns either "parameter(s) not valid : device id" or "no data" for
+  // gibberish input depending on backend mood; both are valid soft-error responses and
+  // both surface as a thrown error from the client. We just assert that it rejects.
+  it('random gibberish rejects', async () => {
+    const account = await WinixAccount.fromCredentials(USERNAME!, PASSWORD!);
+    const client = new WinixClient(account.getIdentityId());
+    await expect(client.getDeviceStatus('not-a-device-id')).rejects.toThrow();
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary
- New `NoDataError` thrown by `WinixClient.getDeviceStatus` when Winix returns `resultMessage: "no data"` or an empty body
- New `MobileSessionInvalidError` thrown by `mobilePost` when Winix returns HTTP 400 with `resultCode` 400 or 900 (the MULTI LOGIN / "user is not valid" path)
- Integration test suite (`test:integration:session`) that probes both failure modes against the live Winix API

## Problem
Two distinct Winix backend behaviors both surfaced as plain `Error` to consumers, with no way to distinguish them from genuine comms failures:

1. **"no data"** — Winix occasionally returns `resultMessage: "no data"` for a registered, online device (transient backend behavior). The plugin treats this as a hard failure, increments `consecutiveFailures`, and after 3 the device flips to "Not Responding" in HomeKit. This is the symptom in homebridge-winix-purifiers#43.
2. **MULTI LOGIN / 400 "user is not valid"** — When the same credentials log in twice (mobile app + plugin, or two plugin instances), the first instance's mobile-plane calls (`getDevices`) start failing with HTTP 400 / resultCode 400 or 900. The control plane (`getDeviceStatus`) survives, so the symptom only bites at startup or during periodic device-list refresh.

Without typed errors, the plugin can't apply different recovery strategies (skip-and-retain vs. re-login).

## Fix
- `NoDataError` and `MobileSessionInvalidError` exported from the package root
- `getDeviceStatusAttributes` branches on `resultMessage === 'no data'` and on empty body, throws `NoDataError`. Other soft errors (`parameter(s) not valid : device id`, `device not registered`, `device not connected`) still throw plain `Error` since those are permanent config mistakes
- `mobilePost` checks `isMobileSessionInvalid(httpStatus, resultCode)` before falling back to the generic error path
- Integration tests assert exact error classes against the real Winix API

## Why
Typed errors let the plugin own recovery without string-matching. Mirrors the existing `RefreshTokenExpiredError` pattern. Splitting the failure modes also matches what iprak/winix (the Home Assistant integration) already learned: "no data" should be treated as soft, MULTI LOGIN should trigger re-auth.

## Test Plan
- `npm run test:integration:session` (requires `.env` with `WINIX_USERNAME`, `WINIX_PASSWORD`, optionally `WINIX_DEVICE_ID`). 6 tests, all green. **Warning: running this invalidates whatever Winix mobile-app session is active for the test account.**
- Verified control plane survives mobile invalidation: `getDeviceStatus` continues to return live data via `client1` after `account1.getDevices()` starts throwing `MobileSessionInvalidError`.