### PR TITLE
fix: handle transient upstream errors and malformed responses

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import {
   DeviceCapabilities, DeviceStatus, Mode, Plasmawave, PollutionLamp, Power, Timer, UV,
 } from './device';
 import { SetAttributeResponse, StatusAttributes, StatusBody, StatusResponse } from './response';
-import { getErrorMessage, isResponseError, NoDataError, RateLimitError } from './error';
+import { getErrorMessage, isResponseError, NoDataError, RateLimitError, UpstreamUnavailableError } from './error';
 import axios, { AxiosResponse, isAxiosError } from 'axios';
 
 const DEFAULT_COOLDOWN_MS = 60_000;
@@ -252,16 +252,29 @@ export class WinixClient {
       try {
         result = await axios.get<StatusResponse>(url);
       } catch (e: unknown) {
-        if (isAxiosError(e) && (e.response?.status === 403 || e.response?.status === 429)) {
+        if (!isAxiosError(e)) {
+          throw e;
+        }
+        if (e.response?.status === 403 || e.response?.status === 429) {
           throw new RateLimitError();
+        }
+        if (!e.response) {
+          throw new UpstreamUnavailableError(e.code ?? e.message);
+        }
+        if (e.response.status >= 500) {
+          throw new UpstreamUnavailableError(`HTTP ${e.response.status}`);
         }
         throw e;
       }
 
-      const resultMessage: string = result.data.headers.resultMessage;
-      const body: StatusBody = result.data.body;
+      const resultMessage: string | undefined = result.data?.headers?.resultMessage;
+      const body: StatusBody | undefined = result.data?.body;
 
-      if (resultMessage === 'no data' || isEmpty(body) || isEmpty(body.data)) {
+      if (typeof resultMessage !== 'string') {
+        throw new UpstreamUnavailableError('malformed response (missing headers.resultMessage)');
+      }
+
+      if (resultMessage === 'no data' || !body || isEmpty(body) || isEmpty(body.data)) {
         throw new NoDataError();
       }
 
@@ -286,13 +299,26 @@ export class WinixClient {
       try {
         result = await axios.get<SetAttributeResponse>(url);
       } catch (e: unknown) {
-        if (isAxiosError(e) && (e.response?.status === 403 || e.response?.status === 429)) {
+        if (!isAxiosError(e)) {
+          throw e;
+        }
+        if (e.response?.status === 403 || e.response?.status === 429) {
           throw new RateLimitError();
+        }
+        if (!e.response) {
+          throw new UpstreamUnavailableError(e.code ?? e.message);
+        }
+        if (e.response.status >= 500) {
+          throw new UpstreamUnavailableError(`HTTP ${e.response.status}`);
         }
         throw e;
       }
 
-      const resultMessage: string = result.data.headers.resultMessage;
+      const resultMessage: string | undefined = result.data?.headers?.resultMessage;
+
+      if (typeof resultMessage !== 'string') {
+        throw new UpstreamUnavailableError('malformed response (missing headers.resultMessage)');
+      }
 
       if (isResponseError(resultMessage)) {
         throw new Error(getErrorMessage(resultMessage));

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,6 +12,15 @@ export class NoDataError extends Error {
   }
 }
 
+// Transient failure talking to Winix's backend: 5xx, network errors (DNS/connect/timeout),
+// or a 2xx with a malformed/non-JSON body. Callers should retain last-known state and retry.
+export class UpstreamUnavailableError extends Error {
+  constructor(public readonly cause: string) {
+    super(`Winix backend unavailable: ${cause}`);
+    this.name = 'UpstreamUnavailableError';
+  }
+}
+
 export class MobileSessionInvalidError extends Error {
   constructor(
     public readonly resultCode: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { WinixAccount, WinixExistingAuth } from './account/winix-account';
 import { RefreshTokenExpiredError, WinixAuth, WinixAuthResponse } from './account/winix-auth';
 import { WinixDevice } from './account/winix-device';
 import { WinixClient } from './client';
-import { MobileSessionInvalidError, NoDataError, RateLimitError } from './error';
+import { MobileSessionInvalidError, NoDataError, RateLimitError, UpstreamUnavailableError } from './error';
 
 export {
   WinixDevice,
@@ -17,6 +17,7 @@ export {
   WinixClient,
   RateLimitError,
   NoDataError,
+  UpstreamUnavailableError,
   MobileSessionInvalidError,
   RefreshTokenExpiredError,
   Power,

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import axios, { AxiosError, AxiosHeaders } from 'axios';
-import { WinixClient, RateLimitError } from '../src';
+import { WinixClient, RateLimitError, NoDataError, UpstreamUnavailableError } from '../src';
 
 vi.mock('axios', async () => {
   const actual = await vi.importActual<typeof import('axios')>('axios');
@@ -184,15 +184,49 @@ describe('WinixClient', () => {
       await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(RateLimitError);
     });
 
-    it('rethrows other axios errors', async () => {
+    it('wraps 5xx axios errors as UpstreamUnavailableError', async () => {
       mockedAxiosGet.mockRejectedValue(createAxiosError(500));
-      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.not.toThrow(RateLimitError);
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(UpstreamUnavailableError);
+    });
+
+    it('wraps 504 gateway timeout as UpstreamUnavailableError with HTTP code', async () => {
+      mockedAxiosGet.mockRejectedValue(createAxiosError(504));
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(/HTTP 504/);
+    });
+
+    it('wraps axios errors with no response (DNS/connect/timeout) as UpstreamUnavailableError', async () => {
+      const err = new AxiosError('getaddrinfo EAI_AGAIN us.api.winix-iot.com', 'EAI_AGAIN');
+      mockedAxiosGet.mockRejectedValue(err);
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(UpstreamUnavailableError);
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(/EAI_AGAIN/);
+    });
+
+    it('rethrows other 4xx axios errors unchanged', async () => {
+      mockedAxiosGet.mockRejectedValue(createAxiosError(404));
       await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(AxiosError);
     });
 
     it('rethrows non-axios errors', async () => {
       mockedAxiosGet.mockRejectedValue(new Error('network failure'));
       await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow('network failure');
+    });
+
+    it('throws UpstreamUnavailableError on malformed body (missing headers)', async () => {
+      mockedAxiosGet.mockResolvedValue({ data: '<html>503 service unavailable</html>' });
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(UpstreamUnavailableError);
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(/malformed/);
+    });
+
+    it('throws UpstreamUnavailableError on null data', async () => {
+      mockedAxiosGet.mockResolvedValue({ data: null });
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(UpstreamUnavailableError);
+    });
+
+    it('throws NoDataError when resultMessage is "no data"', async () => {
+      mockedAxiosGet.mockResolvedValue({
+        data: { headers: { resultCode: 'F', resultMessage: 'no data' }, body: {} },
+      });
+      await expect(client.getDeviceStatus(DEVICE_ID)).rejects.toThrow(NoDataError);
     });
   });
 


### PR DESCRIPTION
## Summary
- New `UpstreamUnavailableError` typed error for transient Winix backend conditions: 5xx responses, network errors with no response (DNS/connect/timeout), and 2xx responses with a malformed/non-JSON body
- Both `getDeviceStatusAttributes` and `setDeviceAttribute` in `WinixClient` now distinguish `RateLimitError` (403/429), `UpstreamUnavailableError` (5xx, no-response), and rethrow other AxiosErrors; both also guard `result.data?.headers?.resultMessage` before reading it
- Exported `UpstreamUnavailableError` from the package entrypoint

## Problem
A user on regaw-leinad/homebridge-winix-purifiers#43 reported `TypeError: Cannot read properties of undefined (reading 'resultMessage')` along with `504` gateway timeouts and `EAI_AGAIN` DNS errors during a period when Winix's backend was unhealthy (their mobile app was also slow/unresponsive). Two problems were folded into one:

1. When Winix's edge returned a 2xx with a non-JSON body (HTML error page, empty body), the client crashed on `result.data.headers.resultMessage` because `result.data` was a string and `.headers` was `undefined`.
2. 5xx responses and network-level errors (DNS, ECONNRESET, timeouts) bubbled up as raw `AxiosError`, giving downstream consumers no way to distinguish transient upstream issues from real bugs.

## Fix
Categorize transient upstream conditions into `UpstreamUnavailableError` so downstream (the homebridge plugin) can keep last-known state and avoid flipping devices to "Not Responding". Guard the response shape access. Existing `RateLimitError` and `NoDataError` paths are unchanged. Non-5xx, non-rate-limit AxiosErrors still rethrow as-is so real bugs aren't masked.

## Why
Mirrors the `NoDataError` pattern from 2.0.1 (#13). Lets the homebridge plugin treat 504s, DNS hiccups, and malformed bodies the same way it already treats `NoDataError`: retain state, retry next interval. The actual root cause (Winix being flaky) is upstream and not fixable here, but with typed errors the plugin can stop surfacing transient noise to HomeKit.

## Test Plan
- New unit tests in `test/client.test.ts` covering: 500/504 wrapping, `EAI_AGAIN`/no-response wrapping, malformed body (HTML string), null `data`, confirmation that 4xx still rethrows as `AxiosError`, and `NoDataError` still throws on `resultMessage === 'no data'`